### PR TITLE
fix 'Error: Include directive failed.'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,9 @@ jobs:
 #      - name: Install R (if needed for R-based docs)
 #        uses: r-lib/actions/setup-r@v2
 
+      - name: Run sidebar renderer
+        run: |
+          ./bin/render-sidebar.sh
       - name: Run builder script
         run: |
           cd beat-orientation


### PR DESCRIPTION
Run quarto render
error: Uncaught (in promise) Error: Include directive failed.
  in file /home/runner/work/rhythmpedia-com/rhythmpedia-com/tatenori-theory/ja/index.qmd,
  could not find file /home/runner/work/rhythmpedia-com/rhythmpedia-com/_sidebar.generated.md.
            throw new Error(errMsg.join("\n"));
                  ^
    at retrieveInclude (file:///opt/quarto/bin/quarto.js:39122:19)
    at standaloneInclude (file:///opt/quarto/bin/quarto.js:39158:11)
    at processMarkdownIncludes (file:///opt/quarto/bin/quarto.js:39388:38)
    at expandIncludes (file:///opt/quarto/bin/quarto.js:39414:11)
    at eventLoopTick (ext:core/01_core.js:175:7)
    at async projectResolveFullMarkdownForFile (file:///opt/quarto/bin/quarto.js:40439:25)
    at async fileExecutionEngine (file:///opt/quarto/bin/quarto.js:42198:26)
    at async addFile (file:///opt/quarto/bin/quarto.js:82673:24)
Error: Process completed with exit code 1.